### PR TITLE
Script from handles to kafka

### DIFF
--- a/Sсript1_from_handles_to_kafka.py
+++ b/Sсript1_from_handles_to_kafka.py
@@ -1,0 +1,32 @@
+import requests
+from kafka import KafkaProducer
+import json
+import time
+
+def get_logs_and_metrics(logs_url, metrics_url):
+    logs_response = requests.get(logs_url)
+    logs_data = logs_response.json()
+
+    metrics_response = requests.get(metrics_url)
+    metrics_data = metrics_response.json()
+
+    return logs_data, metrics_data
+
+def kafka_producer(topic, data):
+    producer = KafkaProducer(
+        bootstrap_servers='localhost:9092',
+        value_serializer=lambda v: json.dumps(v).encode('utf-8')
+    )
+    producer.send(topic, value=data)
+    producer.flush()
+
+def From_handles_to_Kafka(logs_url, metrics_url, topic):
+    while True:
+        logs_data, metrics_data = get_logs_and_metrics(logs_url, metrics_url)
+        kafka_producer(topic, {'column1': logs_data, 'column2': metrics_data})
+        time.sleep(5)
+
+logs_url = "url_logs"
+metrics_url = "url_metrics"
+topic = "quickstart-events1"
+From_handles_to_Kafka(logs_url, metrics_url, topic)


### PR DESCRIPTION
Взял полученные 2 модуля: обращения к ручкам и отправления в кафку. Объединил их в одном скрипте.
Добавил запуск данных функций раз в пять секунд в бесконечном цикле Добавил возможность конфигурации для указания url ручек

Но, к сожалению, без url-ручек сервисов и самих сервисов протестировать это не представилось возможным. Однако, был изменен файл Kafka_producer, чтобы выходные данные были типа {'column1': logs_data, 'column2': metrics_data}, где вместо logs_data и metrics_data были Int32 и String, и оно работало (Script2 работал). Поэтому разобравшись с url-ручками всё также должно заработать.